### PR TITLE
add pyinotify, required for hosted.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-debs/
+debs/*
+!debs/download.txt
 overlay

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ python3-urllib3_1.24.1-1_all.deb
 python3.7-minimal_3.7.3-2+deb10u2_armhf.deb
 python3.7_3.7.3-2+deb10u2_armhf.deb
 python3_3.7.3-1_armhf.deb
+python3-pyinotify_0.9.6-1_all.deb
 ```
+
+The packages are listed in `debs/download.txt`. You can download them all at once with `cat download.txt | xargs apt download`.
 
 Then invoke `make` and you'll end up with a new version of `overlay.squashfs`.

--- a/debs/download.txt
+++ b/debs/download.txt
@@ -1,0 +1,14 @@
+libpython3-stdlib=3.7.3-1
+libpython3.7-minimal=3.7.3-2+deb10u2
+libpython3.7-stdlib=3.7.3-2+deb10u2
+python3-certifi=2018.8.24-1
+python3-chardet=3.0.4-3
+python3-idna=2.6-1
+python3-pkg-resources=40.8.0-1
+python3-requests=2.21.0-1
+python3-six=1.12.0-1
+python3-urllib3=1.24.1-1
+python3.7-minimal=3.7.3-2+deb10u2
+python3.7=3.7.3-2+deb10u2
+python3=3.7.3-1
+python3-pyinotify=0.9.6-1


### PR DESCRIPTION
The overlay.squashfs was not pushed since GitHub does not support LFS object in public forks.